### PR TITLE
修复积分兑换

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -238,7 +238,7 @@ class API:
 
         try:
             if method.upper() == "POST":
-                response = self.session.post(url, headers=session_headers, data=json.dumps(data), timeout=(60, 120))
+                response = self.session.post(url, headers=session_headers, data=data, timeout=(60, 120))
             elif method.upper() == "GET":
                 response = self.session.get(url, headers=session_headers, timeout=(60, 120))
             else:


### PR DESCRIPTION
正确输出{ code : 1, message : Not enough points. Need 500, have 0.0000000000000000 }
错误输出{ code : 1, message : Plan type is required }

缺少请求头——Content-Type: application/json。

 json.dumps(data) 把字典转换成了 JSON 字符串，但当把它传给 data= 参数时，requests 库默认这只是一串普通文本 (Plain Text)。
POST 请求的请求头没有标明格式 JSON。
服务器后台 JSON 解析器无法解析，认为正文是空的。